### PR TITLE
[JEFF] let과 var의 차이

### DIFF
--- a/CS면접/JEFF/js/let과_var의_차이.md
+++ b/CS면접/JEFF/js/let과_var의_차이.md
@@ -1,0 +1,68 @@
+# var
+
+## function scope
+함수 스코프를 갖는다. (var 를 통해,) 함수 내부에서 선언된 변수는 해당 함수 내부에서만 접근이 가능하다.
+
+```tsx
+function func(){
+  var local = "local" 
+  console.log(local) // ✅ 정상출력: local
+}
+console.log(local) // 🚨 ReferenceError: local is not defined
+```
+
+블록 스코프내에 선언될 경우, 해당 블록을 바깥 스코프에서도 접근이 가능하다.
+```tsx
+if(true){
+  var global = "global"
+  console.log(global) // ✅ 정상출력: global
+}
+console.log(global) // ✅ 정상출력: global
+```
+
+## 호이스팅
+var 로 선언된 변수는 호이스팅(hoisting)되어 변수 선언이 코드의 최상단으로 끌어올려진다. 
+
+하지만 초기화는 선언된 위치에서 이뤄지고, 그 전에 호출될 경우 undefined 값을 가진다.
+
+```tsx
+console.log(varHoisting) // ✅ 정상출력: undefined
+var varHoisting = "var-hoisting"
+console.log(varHoisting) // ✅ 정상출력: var-hoisting
+```
+
+<br/>
+<br/>
+<br/>
+
+# let
+
+## block scope
+블록 스코프를 갖는다. (var 를 통해,) 함수를 포함하여 블록 내부에 선언된 변수는 해당 블록 내부에서만 접근이 가능하다.
+
+```tsx
+function func(){
+  let local = "local" 
+  console.log(local) // ✅ 정상출력: local
+}
+console.log(local) // 🚨 ReferenceError: local is not defined
+```
+
+블록 스코프내에 선언될 경우, 해당 블록을 바깥 스코프에서도 접근이 가능하다.
+```tsx
+function func(){
+  let local = "local" 
+  console.log(local) // ✅ 정상출력: local
+}
+console.log(local) // 🚨 ReferenceError: local is not defined
+```
+
+## 호이스팅
+let도 호이스팅되지만, 선언과 초기화가 동시에 이루어지지 않는다. 
+초기화 전에 변수에 접근하려고 하면 ReferenceError가 발생한다.
+
+```tsx
+console.log(letHoisting) // 🚨 ReferenceError: Cannot access 'letHoisting' before initialization
+
+let letHoisting = "let-hoisting"
+```


### PR DESCRIPTION
<div align="end">
<h3> $\color{#FFA832}{🎤 Amy}$ </h3>
<!-- 면접관 입장에서, 질문을 작성해주세요. -->
변수를 선언할 때 let 과 var 사용할 수 있는데, scope 관점에서 어떤 차이가 있는지 말씀해주세요.

</div>

<br/>




<div align="start">
<h3>  $\color{#2699E6}{🤚 Jeff}$ </h3>

<!-- 면접자 입장에서, 질문을 작성해주세요. -->
var 로 선언된 변수는, 함수 레벨의 스코프를 가집니다.
if, switch, for 문 등, 내부에서 var 를 활용한 변수 선언이 있다면, 해당 블록의 바깥 영역에서도 접근가능한 변수가 선언됩니다.
하지만 함수 내부에서 var 를 통해 변수 선언을 한다면, 오로지 해당 함수 내부에서만 선언된 변수에 접근할 수 있습니다.

let 의 경우 블록 스코프를 가지기 때문에, 함수를 포함한 블록 영역 내부에서만 변수의 접근이 유효합니다.
</div>

<br />


<div align="end">
<h3> $\color{#FFA832}{🎤 Amy}$ </h3>
<!-- 면접관 입장에서, 질문을 작성해주세요. -->
let 과 var 를 통해, 선언된 변수의 호이스팅(hoisting) 은 어떻게 다른가요?

</div>

<br/>


<div align="start">
<h3>  $\color{#2699E6}{🤚 Jeff}$ </h3>

<!-- 면접자 입장에서, 질문을 작성해주세요. -->
두 경우 모두, 변수의 호이스팅이 일어나 상단에서 선언이 됩니다.

다만 var 의 경우 undefined 로 우선 초기화되고, 코드상 실제 선언된 위치에서 실제 값이 할당됩니다.

let 의 경우, 상단에서 어떠한 값으로도 초기화가 일어나지 않았기 때문에, 선언된 위치보다 위에서 접근할 경우 래퍼런스 에러(ReferenceError) 가 발생합니다. 
선언된 위치부터 실제 값이 초기화되기 전까지, ReferenceError 가 발생하는 영역을 "Temporal Dead Zone" 이라고 합니다.

</div>

<br />