### PR TITLE
[JEFF] 일반함수와 화살표 함수 차이

### DIFF
--- a/CS면접/JEFF/js/일반함수와_화살표_함수_차이.md
+++ b/CS면접/JEFF/js/일반함수와_화살표_함수_차이.md
@@ -1,0 +1,96 @@
+# 일반 함수 (함수 선언문)
+```tsx
+function declaration(){
+  return "일반함수"
+}
+```
+- 함수명을 반드시 작성해주어야 한다.
+- **함수의 호이스팅** 이 지원되기 때문에 선언 이전에 호출한 함수도 정상 동작한다.
+
+  ```tsx
+  console.log(foo()) // ✅ 정상출력: func-hosting
+
+  function foo(){
+    return "func-hoisting"
+  }
+  ```
+- au
+
+<br/>
+<br/>
+
+# 함수 표현식
+
+```tsx
+const expression = function(){
+  return "표현식"
+}
+```
+  - 변수를 선언하듯, 함수명을 기재하고 함수를 표현한다.
+  - 호이스팅이 지원되지 않아, 다음 예시의 경우 에러를 던진다.
+  ```tsx
+  console.log(foo()) // 🚨 ReferenceError: Cannot access 'foo' before initialization
+  
+  const foo = function(){
+    return "func-hoisting"
+  }
+  ```
+
+<br/>
+<br/>
+
+# 화살표 함수
+
+```tsx
+const arrow = function(){
+  return "화살표"
+}
+```
+  - ES6 에 추가된 문법이다.
+
+  - 함수의 호이스팅이 지원되지 않는다.
+  ```tsx
+  console.log(foo()); // 🚨 ReferenceError: Cannot access 'foo' before initialization
+
+  const foo = () => {
+    return "arrow function"
+  };
+  ```
+
+  - 자신 만의 this 바인딩을 갖지 않고, 함수가 작성된 위치에서의 this 를 그대로 사용
+  ```tsx
+  const obj = {
+    name: "Jeff",
+    regularFunc: function () {
+      console.log(this.name) // 실행 시, 자체적인 this (obj)를 할당받는다.
+    },
+    arrowFunc: () => {
+      console.log(this.name) // 자체적인 this를 갖지 못하고, 화살표 함수가 선언된 위치(obj)의 외부 스코프에서 this 를 캡쳐한다.
+    },
+  };
+  obj.regularFunc() // ✅ 정상출력: Jeff
+  obj.arrowFunc() // ✅ 정상출력: undefined
+  ```
+
+
+
+# 함수 내부의 this 와 관련하여,,
+
+①. this 를 출력하는 함수(화살표 함수 ❌) 를 특정 객체의 외부에 선언하고, 
+②. 해당 객체의 메서드로 함수를 설정한 뒤,
+③. 호출하면? this 는 객체를 참조한다.
+
+```tsx
+/*👇 ① */
+function printThis() {
+  console.log(this)
+}
+
+const obj = {
+  name: "jeff",
+  printName1: printThis // 👈 ②
+}
+
+obj.printName1() // ✅ 정상출력: { name: 'jeff', printName1: [Function: printThis] }
+```
+


### PR DESCRIPTION
<div align="end">
<h3> $\color{#FFA832}{🎤 Amy}$ </h3>
<!-- 면접관 입장에서, 질문을 작성해주세요. -->

'this 바인딩' 을 주제로, 일반함수와 화살표 함수 차이를 설명해주세요.

</div>

<br/>



<div align="start">
<h3>  $\color{#2699E6}{🤚 Jeff}$ </h3>
<!-- 면접자 입장에서, 질문을 작성해주세요. -->

일반함수는 함수가 선언된 환경의 스코프를 this 로 참조하고 있습니다. 
특정 클래스 혹은 오브젝트의 메서드로 일반함수가 선언되어 있다면, 해당 클래스 혹은 오브젝트의 참조값을 함수 내부의 this가 가지고 있어요.
반면 화살표함수는 호출 시, 자신만의 this 를 가지지 못하고 부모의 this 와 같은 참조값을 그대로 가지게 됩니다.
클래스 혹은 오브젝트의 메서드로 선언되어 있어도, 화살표함수의 내부에서 this 를 통해 접근할 수 있는 것은 그 클래스 또는 오브젝트의 부모 환경입니다.

</div>

<br />




<div align="end">
<h3> $\color{#FFA832}{🎤 Amy}$ </h3>
<!-- 면접관 입장에서, 질문을 작성해주세요. -->

'this 바인딩' 외에 차이점이 있을까요?

</div>

<br/>



<div align="start">
<h3>  $\color{#2699E6}{🤚 Jeff}$ </h3>
<!-- 면접자 입장에서, 질문을 작성해주세요. -->

arguments 라는 함수 입력에 대한 차이 또한 있습니다.
일반적으로 javascript 에서는 함수로 전달되는 인자와 선언부의 매개변수의 갯수가 서로 달라도 동작에 오류가 발생하지 않습니다.

일반함수에서 매개변수 이상의 인자가 전달될 경우, arguments 라는 유사배열에 나머지 인자가 저장됩니다. 
이 경우, arguments 는 함수의 선언부에 굳이 명시하지 않아도 접근이 가능합니다.

하지만 화살표 함수는 arguments 라는 객체를 따로 제공하지 않습니다.

</div>

<br />
